### PR TITLE
feat/20 Add execution logging and saving the log

### DIFF
--- a/src/main/java/History.java
+++ b/src/main/java/History.java
@@ -12,8 +12,8 @@ public class History {
      * The method save, saves the information in the parameter, provided from a process.
      * The function assigns a timestamp to the information and saves it as a file with the name
      * commitID + " " + TIMESTAMP in the map build_history
-     * @param buildResult, contains the result from the build
-     * @param commitID, unique ID for the commit/process/push should be searchable
+     * @param buildResult contains the result from the build
+     * @param commitID unique ID for the commit/process/push should be searchable
      */
     public void save(String buildResult, String commitID){
 

--- a/src/main/java/JSONParser.java
+++ b/src/main/java/JSONParser.java
@@ -80,4 +80,15 @@ public class JSONParser {
     private String removeSurroundingQuotes(String string) {
         return string.substring(1, string.length() - 1);
     }
+
+    /**
+     * Gets HEAD commit hash value.
+     *
+     * @return HEAD commit hash value.
+     */
+    public String getHeadCommitHash() {
+        String commit_id = getValue(new String[]{"head_commit", "id"});
+        commit_id = removeSurroundingQuotes(commit_id);
+        return commit_id;
+    }
 }

--- a/src/main/java/LogToString.java
+++ b/src/main/java/LogToString.java
@@ -1,0 +1,33 @@
+import org.apache.commons.exec.LogOutputStream;
+
+public class LogToString extends LogOutputStream {
+    private StringBuilder sb = new StringBuilder();
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param logLevel not used here.
+     */
+    @Override
+    public void processLine(String line, int logLevel) {
+        sb.append(line);
+        sb.append('\n');
+    }
+
+    /**
+     * Return the log information as string.
+     *
+     * @return the log information as string.
+     */
+    @Override
+    public String toString(){
+        return sb.toString();
+    }
+
+    /**
+     * Clears the log history stored in this object.
+     */
+    public void clear() {
+        sb.setLength(0);
+    }
+}

--- a/src/test/java/JSONParserTest.java
+++ b/src/test/java/JSONParserTest.java
@@ -11,15 +11,23 @@ class JSONParserTest {
             "  \"repository\": {\n" +
             "    \"name\": \"testRepoName\",\n" +
             "    \"clone_url\": \"https://github.com/Test/testRepoName.git\",\n" +
+            "  },\n" +
+            "  \"head_commit\": {\n" +
+            "       \"id\": \"abc123\" \n" +
             "  }\n" +
             "}";
+    // missingBracketJsonString has a curly bracket missing at the beginning
     final String missingBracketJsonString = "\n" +
             "  \"ref\": \"refs/heads/testBranchName\",\n" +
             "  \"repository\": {\n" +
             "    \"name\": \"testRepoName\",\n" +
             "    \"clone_url\": \"https://github.com/Test/testRepoName.git\",\n" +
+            "  },\n" +
+            "  \"head_commit\": {\n" +
+            "       \"id\": \"abc123\" \n" +
             "  }\n" +
             "}";
+
     final JSONParser correctJsonParser = new JSONParser(correctJsonString);
     final JSONParser missingBracketJsonParser = new JSONParser(missingBracketJsonString);
 
@@ -58,4 +66,23 @@ class JSONParserTest {
     void getRepoNameException() {
         assertThrows(JSONException.class, missingBracketJsonParser::getRepoName);
     }
+
+    /**
+     * Tests that getHeadCommitHash returns the correct HEAD commit Hash.
+     */
+    @Test
+    @DisplayName("Test getHeadCommitHash correct")
+    void getHeadCommitHash() {
+        assertEquals("abc123", correctJsonParser.getHeadCommitHash());
+    }
+
+    /**
+     * Tests that getHeadCommitHash returns exception if the json object is not correct.
+     */
+    @Test()
+    @DisplayName("Test getHeadCommitHash exception")
+    void getGetHeadCommitHashException() {
+        assertThrows(JSONException.class, missingBracketJsonParser::getHeadCommitHash);
+    }
+
 }

--- a/src/test/java/LogToStringTest.java
+++ b/src/test/java/LogToStringTest.java
@@ -1,0 +1,63 @@
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test class for LogToString class.
+ */
+@DisplayName("Tests LogToString class")
+class LogToStringTest {
+
+    private LogToString lts;
+
+    /**
+     * Create a new LogToString object before each test case.
+     */
+    @BeforeEach
+    void setUp(){
+        lts = new LogToString();
+    }
+
+    /**
+     * Tests that processLine adds new lines every time it is called.
+     * Also, tests that logLevel does not affect the result of the log.
+     */
+    @Test
+    @DisplayName("Test processLine adds new line")
+    void testProcessLineAddNewLine() {
+        lts.processLine("line 1", 0);
+        assertEquals("line 1\n", lts.toString());
+        lts.processLine("line 2", 1);
+        assertEquals("line 1\nline 2\n", lts.toString());
+    }
+
+    /**
+     * Tests the toString returns a string of the log correctly.
+     */
+    @Test
+    @DisplayName("Test toString return correct string")
+    void testToString() {
+        lts.processLine("line 1", 0);
+        assertEquals("line 1\n", lts.toString());
+        lts.processLine("line 2", 1);
+        assertEquals("line 1\nline 2\n", lts.toString());
+        lts.clear();
+        assertEquals("", lts.toString());
+        lts.processLine("line 3", 1);
+        assertEquals("line 3\n", lts.toString());
+    }
+
+    /**
+     * Tests that clear method clears the log correctly.
+     */
+    @Test
+    @DisplayName("Test clear clears the log")
+    void testClear() {
+        lts.processLine("line 1", 0);
+        assertEquals("line 1\n", lts.toString());
+        lts.clear();
+        assertEquals("", lts.toString());
+    }
+}


### PR DESCRIPTION
* A class called LogToString.java class was created that is used by
DefaultExecutor in Builder.java class to send the output of DefaultExecutor
object to LogToString.

* JSONParser.java class now has a method the fetches the has of the HEAD commit
to use it as an id for logging in Builder.java class.

* Builder.java class was edited incorporate LogToString.java class as above.
Also, Builder.java class now calls the save History.java class to save
the output of the class.

* Test cases for LogToString.java and JSONParser class was written.

fixes #20 